### PR TITLE
198 policy service issue with logical deletion in policy service leading to conflict on policy recreation

### DIFF
--- a/product-plane-services/policy-api/src/main/java/org/opendatamesh/platform/pp/policy/api/resources/PolicySearchOptions.java
+++ b/product-plane-services/policy-api/src/main/java/org/opendatamesh/platform/pp/policy/api/resources/PolicySearchOptions.java
@@ -13,7 +13,7 @@ public class PolicySearchOptions {
     @Schema(description = "Retrieve all the policies with this name.")
     private String name;
 
-    @Schema(description = "Retrieve only the last version of the policies.")
+    @Schema(description = "Retrieve only the last version of the policies.", defaultValue = "true")
     private Boolean lastVersion = true;
 
     public String getEvaluationEvent() {

--- a/product-plane-services/policy-server/src/main/java/org/opendatamesh/platform/pp/policy/server/database/repositories/PolicyRepository.java
+++ b/product-plane-services/policy-server/src/main/java/org/opendatamesh/platform/pp/policy/server/database/repositories/PolicyRepository.java
@@ -11,9 +11,9 @@ public interface PolicyRepository extends PagingAndSortingAndSpecificationExecut
 
     Policy findByRootIdAndIsLastVersionTrue(Long rootId);
 
-    boolean existsByNameAndRootIdNot(String name, Long rootId);
+    boolean existsByNameAndIsLastVersionTrueAndRootIdNot(String name, Long rootId);
 
-    boolean existsByName(String name);
+    boolean existsByNameAndIsLastVersionTrue(String name);
 
     class Specs extends SpecsUtils {
 

--- a/product-plane-services/policy-server/src/main/java/org/opendatamesh/platform/pp/policy/server/services/PolicyService.java
+++ b/product-plane-services/policy-server/src/main/java/org/opendatamesh/platform/pp/policy/server/services/PolicyService.java
@@ -40,7 +40,7 @@ public class PolicyService extends GenericMappedAndFilteredCrudService<PolicySea
 
     @Override
     protected void beforeCreation(Policy objectToCreate) {
-        if (repository.existsByName(objectToCreate.getName())) {
+        if (repository.existsByNameAndIsLastVersionTrue(objectToCreate.getName())) {
             throw new UnprocessableEntityException(
                     PolicyApiStandardErrors.SC422_04_POLICY_ALREADY_EXISTS,
                     "Policy with name [" + objectToCreate.getName() + "] already exists"
@@ -122,10 +122,10 @@ public class PolicyService extends GenericMappedAndFilteredCrudService<PolicySea
                     "Policy policyEngineId or PolicyEngine object cannot be null"
             );
         }
-        if (repository.existsByNameAndRootIdNot(policy.getName(), policy.getRootId())) {
+        if (repository.existsByNameAndIsLastVersionTrueAndRootIdNot(policy.getName(), policy.getRootId())) {
             throw new UnprocessableEntityException(
                     PolicyApiStandardErrors.SC422_04_POLICY_ALREADY_EXISTS,
-                    "Policy with name [" + policy.getName() + "] already exists with a differet rootID"
+                    "Policy with name [" + policy.getName() + "] already exists with a different rootID"
             );
         }
     }

--- a/product-plane-services/policy-server/src/test/java/org/opendatamesh/platform/pp/policy/server/PolicyErrorsIT.java
+++ b/product-plane-services/policy-server/src/test/java/org/opendatamesh/platform/pp/policy/server/PolicyErrorsIT.java
@@ -197,7 +197,7 @@ public class PolicyErrorsIT extends ODMPolicyIT {
                 "Policy policyEngineId or PolicyEngine object cannot be null"
         );
 
-        // 42205 - Policy is invalid - Policy with name [" + policy.getName() + "] already exists with a differet rootID
+        // 42205 - Policy is invalid - Policy with name [" + policy.getName() + "] already exists with a different rootID
         policyResource.setPolicyEngine(parentEngineResource);
         policyResource.setRootId(7L);
         policyResource.setCreatedAt(parentPolicyResource.getCreatedAt());
@@ -208,7 +208,7 @@ public class PolicyErrorsIT extends ODMPolicyIT {
                 putResponse,
                 HttpStatus.UNPROCESSABLE_ENTITY,
                 PolicyApiStandardErrors.SC422_04_POLICY_ALREADY_EXISTS,
-                "Policy with name [" + policyResource.getName() + "] already exists with a differet rootID"
+                "Policy with name [" + policyResource.getName() + "] already exists with a different rootID"
         );
 
     }

--- a/product-plane-services/policy-server/src/test/java/org/opendatamesh/platform/pp/policy/server/PolicyIT.java
+++ b/product-plane-services/policy-server/src/test/java/org/opendatamesh/platform/pp/policy/server/PolicyIT.java
@@ -206,6 +206,32 @@ public class PolicyIT extends ODMPolicyIT {
 
     }
 
+    @Test
+    @DirtiesContext(methodMode = DirtiesContext.MethodMode.AFTER_METHOD)
+    public void testDeleteAndRecreatePolicy() throws JsonProcessingException {
+
+        // Resources + Creation
+        PolicyEngineResource parentEngineResource = createPolicyEngine(ODMPolicyResources.RESOURCE_POLICY_ENGINE_1);
+        PolicyResource policyResource = createPolicy(ODMPolicyResources.RESOURCE_POLICY_1, parentEngineResource.getId());
+
+        // DELETE request
+        ResponseEntity<ObjectNode> deleteResponse = policyClient.deletePolicyResponseEntity(policyResource.getId());
+        verifyResponseEntity(deleteResponse, HttpStatus.OK, false);
+
+        // GET request to check that the entity is not on the DB anymore
+        ResponseEntity<ObjectNode> getResponse = policyClient.readOnePolicyResponseEntity(policyResource.getId());
+        verifyResponseErrorObjectNode(
+                getResponse,
+                HttpStatus.NOT_FOUND,
+                PolicyApiStandardErrors.SC404_02_POLICY_NOT_FOUND,
+                "Resource with root ID [" + policyResource.getId() + "] not found"
+        );
+
+        // Creation again
+        PolicyResource policyResource2 = createPolicy(ODMPolicyResources.RESOURCE_POLICY_1, parentEngineResource.getId());
+
+    }
+
 
     // ======================================================================================
     // UTILS


### PR DESCRIPTION
# Description  
This pull request fixes an issue in the policy service where duplicate name checks did not properly account for the `IS_LAST_VERSION` flag. Previously, the check would cause conflicts when recreating policies with the same names as logically deleted policies.  

# Changes  
- Updated the duplicate name check logic to ensure it only considers policies where `IS_LAST_VERSION = true`.  
- Added appropriate tests to verify the updated behavior.  

# Issue Addressed  
Resolves the problem where attempting to create a policy with the same name as a logically deleted one would result in an error.  

# Testing  
- Tested creating new policies with the same names as previously deleted ones to confirm no conflicts occur.  
