### PR TITLE
[Registry] Add optional fqn query parameter to the data product upload API

### DIFF
--- a/product-plane-services/registry-api/src/main/java/org/opendatamesh/platform/pp/registry/api/controllers/AbstractUploadsController.java
+++ b/product-plane-services/registry-api/src/main/java/org/opendatamesh/platform/pp/registry/api/controllers/AbstractUploadsController.java
@@ -47,7 +47,7 @@ public abstract class AbstractUploadsController {
     @ResponseStatus(HttpStatus.CREATED) 
     @Operation(
         summary = "Upload a new data product version",
-        description = "Upload a new data product version using the input descriptor referenced by the rpovided uri."
+        description = "Upload a new data product version using the input descriptor referenced by the provided uri."
         + "Create also the data product specified in the descriptor document if it does not exist yet. "
         + "To create the new data product version only if the data product already exist use the endpoint `POST /products/{id}/versions`. "
         + "\r\n _Note: it is not possible to create a data product without any version associated. " 
@@ -94,14 +94,14 @@ public abstract class AbstractUploadsController {
             )
     })
     public String uploadDataProductVersionEndpoint(
-        @Parameter( 
-            description = "A data product descriptor source", 
-            required = true)
-        @RequestBody(required=false)  DataProductDescriptorLocationResource descriptorLocationRes
+            @Parameter(description = "The fully qualified name of the data product to be created or updated with a new version")
+            @RequestParam(value = "fqn", required = false) String fqn,
+            @Parameter(description = "A data product descriptor source", required = true)
+            @RequestBody(required=false) DataProductDescriptorLocationResource descriptorLocationRes
     ) {
-       return uploadDataProductVersion(descriptorLocationRes);
+       return uploadDataProductVersion(fqn, descriptorLocationRes);
     }
 
-    public abstract String uploadDataProductVersion(DataProductDescriptorLocationResource descriptorLocationRes);
+    public abstract String uploadDataProductVersion(String fqn, DataProductDescriptorLocationResource descriptorLocationRes);
 
 }

--- a/product-plane-services/registry-server/src/main/java/org/opendatamesh/platform/pp/registry/server/services/DataProductService.java
+++ b/product-plane-services/registry-server/src/main/java/org/opendatamesh/platform/pp/registry/server/services/DataProductService.java
@@ -376,12 +376,16 @@ public class DataProductService {
 
     public DataProductVersion uploadDataProductVersion(
         DescriptorLocation descriptorLocation,
+        String fqn,
         boolean createDataProductIfNotExists,
         String serverUrl // TODO remove form here !!!
     ) {
-
-        DataProductVersion dataProductVersion = null;
-        dataProductVersion = descriptorToDataProductVersion(descriptorLocation, serverUrl);
+        DataProductVersion dataProductVersion = descriptorToDataProductVersion(descriptorLocation, serverUrl);
+        if(fqn != null && !fqn.equals(dataProductVersion.getInfo().getDataProductId())) {
+            throw new UnprocessableEntityException(
+                    RegistryApiStandardErrors.SC422_03_DESCRIPTOR_NOT_COMPLIANT,
+                    "Data product fqn [" + fqn + "] indicated as request param does not match with the fqn [" + dataProductVersion.getInfo().getFullyQualifiedName() + "] contained in data product descriptor");
+        }
         return addDataProductVersion(dataProductVersion, createDataProductIfNotExists, serverUrl);
     }
 


### PR DESCRIPTION
Introduced an optional `fqn` query parameter to the upload API (`POST /registry/products/uploads`) to explicitly specify the data product to be created or updated while ensuring backward compatibility with the existing behavior.